### PR TITLE
Disable tests action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,18 @@ jobs:
       - name: Lint
         run: yarn lint
 
-  test:
-    name: "Test"
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12.x
-          cache: yarn
-      - name: Install Dependencies
-        run: yarn install --frozen-lockfile
-      - name: Run Tests
-        run: yarn test
+  # test:
+  #   name: "Test"
+  #   runs-on: ubuntu-latest
+  #
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Node
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 12.x
+  #         cache: yarn
+  #     - name: Install Dependencies
+  #       run: yarn install --frozen-lockfile
+  #     - name: Run Tests
+  #       run: yarn test


### PR DESCRIPTION
The test suite fails by design, so it doesn’t really make sense to run it in CI.