### PR TITLE
Disable embroider

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,12 +20,5 @@ module.exports = function (defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  const { Webpack } = require('@embroider/webpack');
-  return require('@embroider/compat').compatBuild(app, Webpack, {
-    skipBabel: [
-      {
-        package: 'qunit',
-      },
-    ],
-  });
+  return app.toTree();
 };


### PR DESCRIPTION
For some reason new files in `mirage` aren’t detected correctly when embroider is in the mix. Easiest to disable it for now.